### PR TITLE
Better collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,14 @@ fn spawn(mut commands: Commands) {
 }
 ```
 
-You can customize the `interaction_groups` the cloth checks. (See the [rapier docs](https://rapier.rs/docs/user_guides/bevy_plugin/colliders#collision-groups-and-solver-groups)).
+Three [`bevy_rapier`](https://github.com/dimforge/bevy_rapier) components will be automatically inserted:
+- a `RigidBody::KinematicPositionBased`
+- a `Collider` which will be updated every frame to follow the cloth bounds (AABB)
+- a `SolverGroup` set to 0 in everything, avoiding default collision solving.
 
-> Note: Collision support is crude and experimental for now and is not suited for production use
+You can customize what collisions will be check through a `ContactGroup` (See the [rapier docs](https://rapier.rs/docs/user_guides/bevy_plugin/colliders#collision-groups-and-solver-groups)).
+
+> Note: Collision support is still experimental for now and is not suited for production use. Feedback is welcome !
 
 ## Mesh utils
 

--- a/src/collider.rs
+++ b/src/collider.rs
@@ -1,13 +1,10 @@
 use bevy::ecs::component::Component;
-use bevy_rapier3d::prelude::InteractionGroups;
 
 /// Enables collisions on a cloth entity
 ///
-/// The collisions will be detected by casting a cuboid shape using the cloth AABB bounding box
+/// The collisions will be detected through a cuboid shape using the cloth AABB bounding box.
 #[derive(Debug, Clone, Component)]
 pub struct ClothCollider {
-    /// Collision interaction groups, all by default
-    pub interaction_groups: InteractionGroups,
     /// offset to apply on collision projected point to prevent clipping
     pub offset: f32,
     /// Coefficient of the received velocity to apply to cloth:
@@ -23,7 +20,6 @@ pub struct ClothCollider {
 impl Default for ClothCollider {
     fn default() -> Self {
         Self {
-            interaction_groups: InteractionGroups::all(),
             offset: 0.25,
             velocity_coefficient: 1.0,
             dampen_others: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,9 +218,14 @@
 //! }
 //! ```
 //!
-//! You can customize the `interaction_groups` the cloth checks. (See the [rapier docs](https://rapier.rs/docs/user_guides/bevy_plugin/colliders#collision-groups-and-solver-groups)).
+//! Three [`bevy_rapier`](https://github.com/dimforge/bevy_rapier) components will be automatically inserted:
+//! - a `RigidBody::KinematicPositionBased`
+//! - a `Collider` which will be updated every frame to follow the cloth bounds (AABB)
+//! - a `SolverGroup` set to 0 in everything, avoiding default collision solving.
 //!
-//! > Note: Collision support is crude and experimental for now and is not suited for production use
+//! You can customize what collisions will be check through a `ContactGroup` (See the [rapier docs](https://rapier.rs/docs/user_guides/bevy_plugin/colliders#collision-groups-and-solver-groups)).
+//!
+//! > Note: Collision support is still experimental for now and is not suited for production use. Feedback is welcome !
 //!
 //! ## Mesh utils
 //!
@@ -316,7 +321,8 @@ impl Plugin for ClothPlugin {
                 .after("CLOTH_UPDATE"),
         );
         #[cfg(feature = "rapier_collisions")]
-        app.add_system(rapier_collisions::handle_collisions.before("CLOTH_RENDER"));
+        app.add_system(rapier_collisions::init_cloth_collider.after("CLOTH_INIT"))
+            .add_system(rapier_collisions::handle_collisions.before("CLOTH_RENDER"));
         bevy::log::info!("Loaded Cloth Plugin");
     }
 }

--- a/src/rapier_collisions.rs
+++ b/src/rapier_collisions.rs
@@ -9,68 +9,95 @@ use bevy::log::error;
 use bevy::prelude::*;
 use bevy_rapier3d::prelude::*;
 
+fn get_collider(
+    rendering: &ClothRendering,
+    collider: &ClothCollider,
+    matrix: Option<&Mat4>,
+) -> Collider {
+    let (center, extents): (Vec3, Vec3) = rendering.compute_aabb(Some(collider.offset));
+    Collider::compound(vec![(
+        matrix.map_or(center, |mat| mat.transform_point3(center)),
+        Quat::IDENTITY,
+        Collider::cuboid(extents.x, extents.y, extents.z),
+    )])
+}
+
 pub fn handle_collisions(
     mut cloth_query: Query<(
-        &GlobalTransform,
+        Entity,
         &mut Cloth,
         &ClothRendering,
         &ClothCollider,
+        &mut Collider,
     )>,
     rapier_context: Res<RapierContext>,
-    mut colliders_query: Query<(&Collider, &GlobalTransform, Option<&mut Velocity>)>,
+    mut colliders_query: Query<
+        (&Collider, &GlobalTransform, Option<&mut Velocity>),
+        Without<Cloth>,
+    >,
     time: Res<Time>,
 ) {
     let delta_time = time.delta_seconds();
-    for (transform, mut cloth, rendering, collider) in cloth_query.iter_mut() {
-        let matrix: Mat4 = transform.compute_matrix();
-        let (center, extents): (Vec3, Vec3) = rendering.compute_aabb(Some(collider.offset));
-        rapier_context.intersections_with_shape(
-            matrix.transform_point3(center),
-            Quat::IDENTITY,
-            &Collider::cuboid(extents.x, extents.y, extents.z),
-            collider.interaction_groups,
-            None,
-            |entity| {
-                let (other_collider, coll_transform, velocity) =
-                    if let Ok(c) = colliders_query.get_mut(entity) {
-                        c
-                    } else {
-                        error!("Couldn't find collider on entity {:?}", entity);
-                        return false;
-                    };
-                let vel = velocity.as_ref().map_or(0.0, |v| {
-                    v.linvel.length_squared()
-                        * delta_time
-                        * delta_time
-                        * collider.velocity_coefficient
-                });
-                cloth.solve_collisions(|point| {
-                    let projected_point = other_collider.project_point(
-                        coll_transform.translation,
-                        coll_transform.rotation,
-                        *point,
-                        false,
-                    );
-                    let normal: Vec3 = (projected_point.point - *point)
-                        .try_normalize()
-                        .unwrap_or(Vec3::Y);
-                    if projected_point.is_inside {
-                        Some(projected_point.point + (normal * collider.offset) + (normal * vel))
-                    } else if point.distance_squared(projected_point.point)
-                        < collider.offset * collider.offset
-                    {
-                        Some(projected_point.point - (normal * collider.offset))
-                    } else {
-                        None
-                    }
-                });
-                if let Some((ref mut vel, dampen_coef)) = velocity.zip(collider.dampen_others) {
-                    let damp = 1.0 - dampen_coef;
-                    vel.linvel *= damp;
-                    vel.angvel *= damp;
+    for (entity, mut cloth, rendering, collider, mut rapier_collider) in cloth_query.iter_mut() {
+        for contact_pair in rapier_context.contacts_with(entity) {
+            let other_entity = if contact_pair.collider1() == entity {
+                contact_pair.collider2()
+            } else {
+                contact_pair.collider1()
+            };
+            let (other_collider, other_transform, other_velocity) =
+                if let Ok(c) = colliders_query.get_mut(other_entity) {
+                    c
+                } else {
+                    error!("Couldn't find collider on entity {:?}", entity);
+                    continue;
+                };
+            let vel = other_velocity.as_ref().map_or(0.0, |v| {
+                v.linvel.length_squared() * delta_time * delta_time * collider.velocity_coefficient
+            });
+            cloth.solve_collisions(|point| {
+                let projected_point = other_collider.project_point(
+                    other_transform.translation,
+                    other_transform.rotation,
+                    *point,
+                    false,
+                );
+                let normal: Vec3 = (projected_point.point - *point)
+                    .try_normalize()
+                    .unwrap_or(Vec3::Y);
+                if projected_point.is_inside {
+                    Some(projected_point.point + (normal * collider.offset) + (normal * vel))
+                } else if point.distance_squared(projected_point.point)
+                    < collider.offset * collider.offset
+                {
+                    Some(projected_point.point - (normal * collider.offset))
+                } else {
+                    None
                 }
-                true
-            },
-        );
+            });
+            if let Some((ref mut vel, dampen_coef)) = other_velocity.zip(collider.dampen_others) {
+                let damp = 1.0 - dampen_coef;
+                vel.linvel *= damp;
+                vel.angvel *= damp;
+            }
+        }
+        *rapier_collider = get_collider(rendering, collider, None);
+    }
+}
+
+pub fn init_cloth_collider(
+    mut commands: Commands,
+    cloth_query: Query<
+        (Entity, &GlobalTransform, &ClothRendering, &ClothCollider),
+        (With<Cloth>, Without<Collider>),
+    >,
+) {
+    for (entity, transform, rendering, collider) in cloth_query.iter() {
+        let matrix = transform.compute_matrix();
+        commands
+            .entity(entity)
+            .insert(RigidBody::KinematicPositionBased)
+            .insert(get_collider(rendering, collider, Some(&matrix)))
+            .insert(SolverGroups::new(0, 0));
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -55,7 +55,7 @@ pub fn render_cloth(
             rendering.update_positions(cloth.compute_vertex_positions(transform));
             rendering.apply(mesh);
         } else {
-            warn!("A Cloth has a `ClothRendering` component without a loaded mesh");
+            warn!("A Cloth has a `ClothRendering` component without a loaded mesh handle");
         }
     }
 }


### PR DESCRIPTION
Instead of using `RapierContext::intersection_with_shape` every frame and using its *query pipeline* we add the following to the cloth with a `ClothCollider`:
- a `RigidBody::KinematicPositionBased`
- a `Collider` which will be updated every frame to follow the cloth bounds (AABB)
- a `SolverGroup` set to 0 in everything, avoiding default collision solving.

We remove the `interaction_groups` field from `ClothCollider`, this feature can be used with a `CollisionGroups` component: https://rapier.rs/docs/user_guides/bevy_plugin/colliders#collision-groups-and-solver-groups
