### PR TITLE
Upgrade to Bevy 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* Bump `bevy` to `0.12.x`
+* Bump `bevy_rapier3d` to `0.23.x`
+* Bump `bevy_inspector_egui` to `0.21.x`
 * Fixed clippy warnings for rust 1.72.0 (#19)
 * Added rustfmt config (#19)
 * Added vertex colors in flag example (#19)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,23 +21,23 @@ rapier_collisions = ["bevy_rapier3d"]
 thiserror = "1.0"
 
 [dependencies.bevy]
-version = "0.11"
+version = "0.12"
 default-features = false
 features = ["bevy_render", "bevy_asset"]
 
 [dependencies.bevy_rapier3d]
-version = "0.22"
+version = "0.23"
 optional = true
 default-features = false
 features = ["dim3", "async-collider"]
 
 [dev-dependencies]
-bevy-inspector-egui = "0.19"
-bevy_rapier3d = "0.22"
+bevy-inspector-egui = "0.21"
+bevy_rapier3d = "0.23"
 rand = "0.8"
 
 [dev-dependencies.bevy]
-version = "0.11"
+version = "0.12"
 features = [
   "bevy_asset",
   "bevy_winit",

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ use bevy_silk::prelude::*;
 
 fn main() {
   App::new()
-    .add_plugins(DefaultPlugins)
-    .add_plugin(ClothPlugin)
+    .add_plugins((DefaultPlugins, ClothPlugin))
     // ... Add your resources and systems
     .run();
 }
@@ -170,14 +169,13 @@ use bevy_silk::prelude::*;
 
 fn main() {
   App::new()
-    .add_plugins(DefaultPlugins)
+    .add_plugins((DefaultPlugins, ClothPlugin))
     .insert_resource(ClothConfig {
         gravity: Vec3::new(0.0, -9.81, 0.0),
         friction: 0.02,
         sticks_computation_depth: 5,
         acceleration_smoothing: AccelerationSmoothing::default()
     })
-    .add_plugin(ClothPlugin)
     // ... Add your resources and systems
     .run();
 }
@@ -203,7 +201,7 @@ use bevy_silk::prelude::*;
 
 fn main() {
   App::new()
-    .add_plugins(DefaultPlugins)
+    .add_plugins((DefaultPlugins, ClothPlugin))
     .insert_resource(Winds {
         wind_forces: vec![Wind::SinWave {
             max_velocity: Vec3::new(10.0, 15.0, -5.0),
@@ -212,7 +210,6 @@ fn main() {
             abs: false
         }]
     })
-    .add_plugin(ClothPlugin)
     // ... Add your resources and systems
     .run();
 }

--- a/examples/camera_plugin.rs
+++ b/examples/camera_plugin.rs
@@ -41,7 +41,7 @@ pub fn handle_camera(
     let up = transform.local_y();
     // Rotate
     if buttons.pressed(MouseButton::Left) {
-        for ev in motion_evr.iter() {
+        for ev in motion_evr.read() {
             let delta = -ev.delta * delta_time * 0.1;
             transform.rotate_y(delta.x);
             transform.rotate_local_x(delta.y);
@@ -49,14 +49,14 @@ pub fn handle_camera(
     }
     // Pan
     if buttons.pressed(MouseButton::Right) {
-        for ev in motion_evr.iter() {
+        for ev in motion_evr.read() {
             let delta = ev.delta * delta_time;
             transform.translation += -right * delta.x;
             transform.translation += up * delta.y;
         }
     }
     // Zoom
-    for ev in scroll_evr.iter() {
+    for ev in scroll_evr.read() {
         transform.translation += ev.y * delta_time * forward * 10.0;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,7 @@
 //!
 //! fn main() {
 //!   App::new()
-//!     .add_plugins(DefaultPlugins)
-//!     .add_plugin(ClothPlugin)
+//!     .add_plugins((DefaultPlugins, ClothPlugin))
 //!     // ... Add your resources and systems
 //!     .run();
 //! }
@@ -161,14 +160,13 @@
 //!
 //! fn main() {
 //!   App::new()
-//!     .add_plugins(DefaultPlugins)
+//!     .add_plugins((DefaultPlugins, ClothPlugin))
 //!     .insert_resource(ClothConfig {
 //!         gravity: Vec3::new(0.0, -9.81, 0.0),
 //!         friction: 0.02,
 //!         sticks_computation_depth: 5,
 //!         acceleration_smoothing: AccelerationSmoothing::default()
 //!     })
-//!     .add_plugin(ClothPlugin)
 //!     // ... Add your resources and systems
 //!     .run();
 //! }
@@ -194,7 +192,7 @@
 //!
 //! fn main() {
 //!   App::new()
-//!     .add_plugins(DefaultPlugins)
+//!     .add_plugins((DefaultPlugins, ClothPlugin))
 //!     .insert_resource(Winds {
 //!         wind_forces: vec![Wind::SinWave {
 //!             max_velocity: Vec3::new(10.0, 15.0, -5.0),
@@ -203,7 +201,6 @@
 //!             abs: false
 //!         }]
 //!     })
-//!     .add_plugin(ClothPlugin)
 //!     // ... Add your resources and systems
 //!     .run();
 //! }


### PR DESCRIPTION
Updates dependencies to support Bevy 0.12 and replaces the depracated `iter` method to `read` for event readers. A really easy migration :)